### PR TITLE
Rename opencv to opencv4 for ubuntu20.04

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,25 @@
+# In earlier versions opencv library was identifies 'opencv'
+# without any version number in pkg-config
+# Since the released used in Ubuntu 20.04 this changed and the 
+# name now is 'opencv4'.
+#
+# The following lines identify the Ubuntu release version
+# and select the library name accordingly.
+#
+find_program(LSB_RELEASE_EXEC lsb_release)
+execute_process(COMMAND ${LSB_RELEASE_EXEC} -rs
+    OUTPUT_VARIABLE LSB_RELEASE_ID_SHORT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(LSB_RELEASE_ID_SHORT STREQUAL 20.04)
+    set(OPENCVLIBNAME opencv4)
+else()
+    set(OPENCVLIBNAME opencv)
+endif()
+
 rock_library(projection
-    DEPS_PKGCONFIG opencv eigen3
+    DEPS_PKGCONFIG ${OPENCVLIBNAME} eigen3
     SOURCES Homography.cpp Omnidirectional.cpp
     HEADERS Homography.hpp StereoTriangulation.hpp Omnidirectional.hpp OmnidirectionalConfig.hpp)
 


### PR DESCRIPTION
Account for different name used to identify OpenCV in pkg-config in Ubuntu20.04. New name is 'opencv4'.

Note that the implemented solution is suboptional, as it is specific to a certain linux distro and the distro number might actually not be the most crucial factor the decision should be made on. Suggestions for improvement are welcome.